### PR TITLE
When the attribute METHOD of EXT-X-KEY is NONE, the key is not processed

### DIFF
--- a/src/avprotocol/m3u8/parser.ts
+++ b/src/avprotocol/m3u8/parser.ts
@@ -535,14 +535,17 @@ function parseSegment(
       if (segment.parts.length > 0) {
         logger.fatal('EXT-X-KEY must appear before the first EXT-X-PART tag of the Parent Segment.')
       }
-      setCompatibleVersionOfKey(params, attributes)
-      segment.key = new Key({
-        method: attributes['METHOD'],
-        uri: attributes['URI'],
-        iv: attributes['IV'],
-        format: attributes['KEYFORMAT'],
-        formatVersion: attributes['KEYFORMATVERSIONS']
-      })
+
+      if (attributes['METHOD'] !== 'NONE') {
+        setCompatibleVersionOfKey(params, attributes)
+        segment.key = new Key({
+          method: attributes['METHOD'],
+          uri: attributes['URI'],
+          iv: attributes['IV'],
+          format: attributes['KEYFORMAT'],
+          formatVersion: attributes['KEYFORMATVERSIONS']
+        })
+      }
     }
     else if (name === 'EXT-X-MAP') {
       if (segment.parts.length > 0) {
@@ -666,14 +669,16 @@ function parsePrefetchSegment(
       segment.discontinuity = true
     }
     else if (name === 'EXT-X-KEY') {
-      setCompatibleVersionOfKey(params, attributes)
-      segment.key = new Key({
-        method: attributes['METHOD'],
-        uri: attributes['URI'],
-        iv: attributes['IV'],
-        format: attributes['KEYFORMAT'],
-        formatVersion: attributes['KEYFORMATVERSIONS']
-      })
+      if (attributes['METHOD'] !== 'NONE') {
+        setCompatibleVersionOfKey(params, attributes)
+        segment.key = new Key({
+          method: attributes['METHOD'],
+          uri: attributes['URI'],
+          iv: attributes['IV'],
+          format: attributes['KEYFORMAT'],
+          formatVersion: attributes['KEYFORMATVERSIONS']
+        })
+      }
     }
     else if (name === 'EXT-X-MAP') {
       logger.fatal('Prefetch segments must not be advertised with an EXT-X-MAP tag.')


### PR DESCRIPTION
## Description

![image](https://github.com/zhaohappy/libmedia/assets/50061726/ffb787c1-a6c6-4753-9080-b27e898fa5bf)

M3u8 Parser did not handle the EXT-X-KEY attribute with NONE, resulting in keyURL being none. Executing buildAbsoluteURL resulted in an exception

[reference: EXT-X-KEY](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.4)



