### PR TITLE
修复当#EXT-X-ENDLIST前存在#EXT-X-DISCONTINUITY时解析segment为空，导致计算duration异常无法seek

### DIFF
--- a/src/avprotocol/m3u8/parser.ts
+++ b/src/avprotocol/m3u8/parser.ts
@@ -867,7 +867,7 @@ function parseMediaPlaylist(lines: Line[], params: Record<string, any>) {
     checkLowLatencyCompatibility(playlist, containsParts)
   }
   playlist.duration = playlist.segments.reduce((total, segment) => {
-    return total + segment.duration
+    return typeof segment.duration === 'number' ? total + segment.duration : total
   }, 0)
   return playlist
 }


### PR DESCRIPTION
## Description

测试资源地址：https://v11.fentvoss.com/sdv11/202406/26/gee3bhggZh3/video/index.m3u8

```bash
......
#EXTINF:0.080000,
/xxx.ts
#EXT-X-DISCONTINUITY
#EXT-X-ENDLIST
```

修复当#EXT-X-ENDLIST前存在#EXT-X-DISCONTINUITY时解析segment为空，导致计算duration异常无法seek