### PR TITLE
fix: 不支持WebGPU的设备播放时黑屏

### DIFF
--- a/product/player/player.html
+++ b/product/player/player.html
@@ -53,12 +53,118 @@
   <script src="../../dist/cheap-polyfill.js"></script>
   <script src="../../dist/avplayer-ui/avplayer.js"></script>
 
-  <script>
+  <script defer type="module">
 
     let supportAtomic = false
     let supportSimd = false
 
     const backgroundVideo = document.querySelector('#background-video')
+
+    let webgpu = false;
+
+    // 测试WebGPU是否可用
+    try{
+        const clearColor = { r: 0.0, g: 0.5, b: 1.0, a: 1.0 },
+            vertices = new Float32Array([
+                0.0,  0.6, 0, 1, 1, 0, 0, 1,
+                -0.5, -0.6, 0, 1, 0, 1, 0, 1,
+                0.5, -0.6, 0, 1, 0, 0, 1, 1
+            ]),shaders = `
+struct VertexOut {
+  @builtin(position) position : vec4f,
+  @location(0) color : vec4f
+}
+
+@vertex
+fn vertex(@location(0) position: vec4f,
+               @location(1) color: vec4f) -> VertexOut
+{
+  var output : VertexOut;
+  output.position = position;
+  output.color = color;
+  return output;
+}
+
+@fragment
+fn fragment(fragData: VertexOut) -> @location(0) vec4f
+{
+  return fragData.color;
+}
+    `;
+        const adapter = await navigator.gpu.requestAdapter(),
+            device = await adapter.requestDevice(),
+            shaderModule = device.createShaderModule({ code: shaders });
+
+        const canvas = document.createElement('canvas'),
+            context = canvas.getContext('webgpu');
+
+        context.configure({
+            device,
+            format: navigator.gpu.getPreferredCanvasFormat(),
+            alphaMode: 'premultiplied'
+        });
+
+        const vertexBuffer = device.createBuffer({
+            size: vertices.byteLength,
+            usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+        });
+
+        device.queue.writeBuffer(vertexBuffer, 0, vertices, 0, vertices.length);
+
+        const vertexBuffers = [{
+                attributes: [{
+                    shaderLocation: 0, // position
+                    offset: 0,
+                    format: 'float32x4'
+                }, {
+                    shaderLocation: 1, // color
+                    offset: 16,
+                    format: 'float32x4'
+                }],
+                arrayStride: 32,
+                stepMode: 'vertex'
+            }],pipelineDescriptor = {
+                vertex: {
+                    module: shaderModule,
+                    entryPoint: 'vertex_main',
+                    buffers: vertexBuffers
+                },
+                fragment: {
+                    module: shaderModule,
+                    entryPoint: 'fragment',
+                    targets: [{
+                        format: navigator.gpu.getPreferredCanvasFormat()
+                    }]
+                },
+                primitive: {
+                    topology: 'triangle-list'
+                },
+                layout: 'auto'
+            };
+
+        const renderPipeline = device.createRenderPipeline(pipelineDescriptor),
+            commandEncoder = device.createCommandEncoder(),
+            renderPassDescriptor = {
+                colorAttachments: [{
+                clearValue: clearColor,
+                loadOp: 'clear',
+                storeOp: 'store',
+                view: context.getCurrentTexture().createView()
+                }]
+            },
+            passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+
+        passEncoder.setPipeline(renderPipeline);
+        passEncoder.setVertexBuffer(0, vertexBuffer);
+        passEncoder.draw(3);
+        passEncoder.end();
+        device.queue.submit([commandEncoder.finish()]);
+
+        webgpu = true;
+    }catch(e){
+        console.warn('Your device doesnot support WebGPU.');
+        console.debug(e);
+    }
 
     const player = new AVPlayer({
       container: document.querySelector('#app'),
@@ -140,6 +246,7 @@
       indicatorUrl: '../../src/ui/avplayer/img/indicator.svg',
       pauseStateUrl: '../../src/ui/avplayer/img/state.svg',
       errorStateUrl: '../../src/ui/avplayer/img/error.svg',
+      "enableWebGPU": webgpu,
       fullscreenDom: document.body
     })
 


### PR DESCRIPTION
在一些老旧设备（大概2015以前），WebGPU无法工作，提示: `No available adapters.`导致黑屏

![image](https://github.com/user-attachments/assets/39450599-3e26-4b3a-ab16-8572e82b57a6)

我的修改可做参考，判断是否真实可用再启用WebGPU