### PR TITLE
fix: 修复`useMSE`模式下setVolume报错问题

### DIFF
--- a/src/avplayer/AVPlayer.ts
+++ b/src/avplayer/AVPlayer.ts
@@ -2536,7 +2536,7 @@ export default class AVPlayer extends Emitter implements ControllerObserver {
    * 
    */
   public setVolume(volume: number, force: boolean = false) {
-    this.volume = restrain(volume, 0, 3)
+    this.volume = this.useMSE ? restrain(volume, 0, 1) : restrain(volume, 0, 3)
     if (this.gainNode && AVPlayer.audioContext) {
       this.gainNode.gain.cancelScheduledValues(AVPlayer.audioContext.currentTime)
 


### PR DESCRIPTION
```js
Uncaught IndexSizeError: Failed to set the 'volume' property on 'HTMLMediaElement': The volume provided (2.4) is outside the range [0, 1]
```
当 `useMSE` 为true，`setVolume` 超出[0,1]会报错