### PR TITLE
Fixed webpack build issue with build-transformer

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,6 +137,11 @@ module.exports = (env) => {
       aggregateTimeout: 1000,
       ignored: /node_modules|output/
     },
+    ...(env.transformer ? {
+      node: {
+        __dirname: false
+      }
+    } : {}),
     resolve: {
       extensions: ['.js', '.ts', '.json'],
       modules: [


### PR DESCRIPTION
This prevents webpack from compiling __dirname to '/' instead of leaving '__dirname' unchanged when the build-transformer script from package.json is run to compile transformer.js

https://webpack.js.org/configuration/node/#node__dirname